### PR TITLE
Fix example to be able to match tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,29 @@ Create the file `android/src/main/res/xml/nfc_tech_filter.xml` and add the follo
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <tech-list>
         <tech>android.nfc.tech.IsoDep</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.NfcA</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.NfcB</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.NfcF</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.NfcV</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.Ndef</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.NdefFormatable</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.MifareClassic</tech>
+    </tech-list>
+    <tech-list>
         <tech>android.nfc.tech.MifareUltralight</tech>
     </tech-list>
 </resources>


### PR DESCRIPTION
The example XML file in README was wrong. Looking at [NFC basics](https://developer.android.com/guide/topics/connectivity/nfc/nfc.html#tech-disc) it says:
> Your activity is considered a match if a tech-list set is a subset of the technologies that are supported by the tag

This means that if my tag supports `IsoDep` and `NfcA` I do not get event from this library because the current `tech-list` is NOT subset of `IsoDep` and `NfcA`. But when when all techs are in own `tech-list` they are always subset of tag's supported techs. So basically doing XML file like this it is good default when trying out the library. Later on if the coder wants he can filter out techs that he does not want :)

@smitch88 also explained this problem in #7 

This will fix issues #1 #2 #4 #7 

Please ask if you have more questions :)